### PR TITLE
Use return() instead of global assignment

### DIFF
--- a/R/MULTIseq.Classification.Suite.R
+++ b/R/MULTIseq.Classification.Suite.R
@@ -92,7 +92,7 @@ findThresh <- function(call.list) {
   colnames(res)[2:4] <- c("Subset","nCells","Proportion")
 
   extrema <- res$q[localMaxima(res$Proportion[which(res$Subset == "pSinglet")])]
-  return(list("extrema" = extrema, "res" = res)
+  return(list("extrema" = extrema, "res" = res))
 }
 
 #################

--- a/R/MULTIseq.Classification.Suite.R
+++ b/R/MULTIseq.Classification.Suite.R
@@ -71,7 +71,7 @@ classifyCells <- function(barTable, q) {
 ################
 ## findThresh ##
 ################
-findThresh <- function(call.list, id) {
+findThresh <- function(call.list) {
   require(reshape2)
 
   res <- as.data.frame(matrix(0L, nrow=length(call.list), ncol=4))
@@ -90,10 +90,9 @@ findThresh <- function(call.list, id) {
   res <- melt(res, id.vars="q")
   res[,4] <- res$value/nCell
   colnames(res)[2:4] <- c("Subset","nCells","Proportion")
-  assign(x=paste("res_",id,sep=""), value=res, envir = .GlobalEnv)
 
   extrema <- res$q[localMaxima(res$Proportion[which(res$Subset == "pSinglet")])]
-  assign(x=paste("extrema_",id,sep=""), value=extrema, envir = .GlobalEnv)
+  return(list("extrema" = extrema, "res" = res)
 }
 
 #################

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ for (q in seq(0.01, 0.99, by=0.02)) {
 }
 
 ## Identify ideal inter-maxima quantile to set barcode-specific thresholds
-findThresh(call.list=bar.table_sweep.list, id="round1")
-ggplot(data=res_round1, aes(x=q, y=Proportion, color=Subset)) + geom_line() + theme(legend.position = "none") +
-  geom_vline(xintercept=extrema_round1, lty=2) + scale_color_manual(values=c("red","black","blue"))
+threshold.results1 <- findThresh(call.list=bar.table_sweep.list)
+ggplot(data=threshold.results1$res, aes(x=q, y=Proportion, color=Subset)) + geom_line() + theme(legend.position = "none") +
+  geom_vline(xintercept=threshold.results1$extrema, lty=2) + scale_color_manual(values=c("red","black","blue"))
 ```
 ![alternativetext](/Figures/Tutorial_good.qsweep.png)
 
@@ -129,7 +129,7 @@ If this plot does not resemble the visualized distribution above, there may be m
 
 ```R
 ## Finalize round 1 classifications, remove negative cells
-round1.calls <- classifyCells(bar.table, q=findQ(res_round1, extrema_round1))
+round1.calls <- classifyCells(bar.table, q=findQ(threshold.results1$res, threshold.results1$extrema))
 neg.cells <- names(round1.calls)[which(round1.calls == "Negative")]
 bar.table <- bar.table[-which(rownames(bar.table) %in% neg.cells), ]
 
@@ -143,8 +143,8 @@ for (q in seq(0.01, 0.99, by=0.02)) {
   names(bar.table_sweep.list)[n] <- paste("q=",q,sep="")
 }
 
-findThresh(call.list=bar.table_sweep.list, id="round2")
-round2.calls <- classifyCells(bar.table, q=findQ(res_round2, extrema_round2))
+threshold.results2 <- findThresh(call.list=bar.table_sweep.list)
+round2.calls <- classifyCells(bar.table, q=findQ(threshold.results1$res, threshold.results2$extrema))
 neg.cells <- c(neg.cells, names(round2.calls)[which(round2.calls == "Negative")])
 
 ## Repeat until all no negative cells remain (usually 3 rounds)...


### PR DESCRIPTION
Hello,

We are trying out the new version of your classifier.  I am wondering if you'd consider this modification, which updates findThresh() to return a list of results, instead of globally assigning variables?  I also updated your README to reflect this new pattern.  return() is a bit cleaner.

The ultimate reason for this (and I'd be happy to do another PR with this code), if that I wrote a function to encapsulate one round of calling, such that we can perform multiple rounds easily, approximately like:

r1 <- performRoundOfMultiSeqCalling(bar.table.full, 1)
neg.cells <- c(neg.cells, r1$neg.cells)
final.calls <- r1$final.calls
    
r2 <- performRoundOfMultiSeqCalling(r1$bar.table, 2)
neg.cells <- c(neg.cells, r2$neg.cells)
final.calls <- r2$final.calls
      
r3 <- performRoundOfMultiSeqCalling(r2$bar.table, 3)
neg.cells <- c(neg.cells, r3$neg.cells)
final.calls <- r3$final.calls
